### PR TITLE
Fix typo 'absolutly'

### DIFF
--- a/bitrix/modules/main/classes/general/component.php
+++ b/bitrix/modules/main/classes/general/component.php
@@ -293,7 +293,7 @@ class CBitrixComponent
 	/**
 	* Function initializes the component. Returns true on success.
 	*
-	* <p>It is absolutly necessery to call this function before any component usage.</p>
+	* <p>It is absolutely necessery to call this function before any component usage.</p>
 	* @param string $componentName
 	* @param string $componentTemplate
 	* @return bool


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'absolutely', you typed 'absolutly'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            